### PR TITLE
feat: updated copy to clipboard function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
+        "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^9.0.1",
         "react-redux": "^8.1.2",
@@ -9553,6 +9554,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-copy-to-clipboard": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || 16 || 17 || 18"
       }
     },
     "node_modules/react-devtools-inline": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
+    "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
     "react-redux": "^8.1.2",

--- a/src/components/Widgets/YamlViewer/YamlViewer.tsx
+++ b/src/components/Widgets/YamlViewer/YamlViewer.tsx
@@ -5,6 +5,7 @@ import { Button } from 'antd'
 import { CopyOutlined } from '@ant-design/icons'
 import styles from './styles.module.scss'
 import { useState } from 'react'
+import {CopyToClipboard} from 'react-copy-to-clipboard';
 
 const YamlViewer = ({ json }: { json: string }) => {
   const [isCopied, setIsCopied] = useState(false)
@@ -17,15 +18,15 @@ const YamlViewer = ({ json }: { json: string }) => {
       <div className={styles.button}>
         {isCopied && 'Copied to clipboard'}
         
-        <Button 
-          icon={<CopyOutlined />}
-          onClick={() => {
+        <CopyToClipboard
+          onCopy={() => {
             setIsCopied(true)
-            navigator.clipboard.writeText(yamlString)
             setTimeout(() => setIsCopied(false), 2500)
           }}
-          size='large' 
-        />
+          text={yamlString}
+        >
+          <Button icon={<CopyOutlined />} size='large' />
+        </CopyToClipboard>
       </div>
 
       <div className={styles.codeViewer}>


### PR DESCRIPTION
This PR introduces the `react-copy-to-clipboard` library to extend browser compatibility when copying elements to the clipboard.